### PR TITLE
Use builder instead of cli as main

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Requires PHP 5.3 or greater.
 
 ## Usage
 
-    php cli.php update
+    php Builder.php update
 Updates all scheme and template repositories as defined in `schemes.yaml` and `templates.yaml`.
 
-    php cli.php
+    php Builder.php
 Build all templates using all schemes
 
 ## Why PHP?


### PR DESCRIPTION
Perhaps we could also consider using `builder.php` instead of `Builder.php` so the entire statement is lowercase.