### PR TITLE
Support for Terminal.app templates

### DIFF
--- a/Builder.php
+++ b/Builder.php
@@ -11,6 +11,11 @@ $templates_list = 'sources/templates/list.yaml';
 $loader = require __DIR__ . '/vendor/autoload.php';
 
 use Base16\Builder;
+use CFPropertyList\CFTypeDetector;
+use CFPropertyList\CFPropertyList;
+use CFPropertyList\CFData;
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Exception\ParseException;
 
 $builder = new Builder;
 
@@ -31,7 +36,7 @@ switch (@$argv[1]) {
 		echo "Base16 Builder PHP CLI\n";
 		echo "https://github.com/chriskempson/base16-builder-php\n";
 		break;
-	
+
 	/**
 	* Updates template and scheme sources
 	*/
@@ -56,21 +61,87 @@ switch (@$argv[1]) {
 	*/
 	default:
 
+		$term_plist = null;
+		$color = null;
+		$detector = new CFTypeDetector();
+		exec('plutil -help', $out, $no_plutil);
+
+		if (@$argv[1] === '-p') {
+			if ($no_plutil) {
+				fwrite(STDERR, "Builder.php: Cannot work with PLIST files without plutil");
+				exit(127);
+			}
+			if (empty($argv[2])) {
+				fwrite(STDERR, "Builder.php: PLIST file argument is missing");
+				exit(1);
+			}
+			try {
+				$term_plist = new CFPropertyList($argv[2]);
+			}
+			catch (CFPropertyList\IOException $ex) {
+				fwrite(STDERR, "Builder.php: Cannot read PLIST file " . $argv[2]);
+				exit(66);
+			}
+			catch (Exception $ex) {
+				fwrite(STDERR, "Builder.php: Cannot parse PLIST file " . $argv[2]);
+				exit(66);
+			}
+			if (!$term_plist) {
+				fwrite(STDERR, "Builder.php: PLIST file " . $argv[2] . " is empty");
+				exit(66);
+			}
+		}
+
 		// Loop templates repositories
 		foreach ($tpl_list as $tpl_name => $tpl_url) {
 
-			$tpl_confs = $builder->parse(
-				"templates/$tpl_name/templates/config.yaml");
+			$tpl_confs = $builder->parse("templates/$tpl_name/templates/config.yaml");
 
 			// Loop template files
 			foreach ($tpl_confs as $tpl_file => $tpl_conf) {
 
-				$file_path = "templates/$tpl_name/" 
-					. $tpl_conf['output'];
+				if (@$tpl_conf['colorTemplate'] && ($term_plist || @$tpl_conf['plistTemplate'])) {
+					if ($no_plutil) {
+						fwrite(STDERR, "Skipping $tpl_name/$tpl_file because plutil is not installed.\n");
+						continue;
+					}
+					try {
+						$term_plist = new CFPropertyList("templates/$tpl_name/templates/" . $tpl_conf['plistTemplate']);
+					}
+					catch (CFPropertyList\IOException $ex) {
+						fwrite(STDERR, "Builder.php: Cannot read PLIST file" . $tpl_conf['plistTemplate']);
+						exit(66);
+					}
+					catch (Exception $ex) {
+						fwrite(STDERR, "Builder.php: Cannot parse PLIST file" . $tpl_conf['plistTemplate']);
+						exit(66);
+					}
+					if (!$term_plist) {
+						fwrite(STDERR, "Builder.php: PLIST file" . $tpl_conf['plistTemplate'] . " is empty");
+						exit(66);
+					}
+					try {
+						$color = new CFPropertyList("templates/$tpl_name/templates/" . $tpl_conf['colorTemplate']);
+					}
+					catch (CFPropertyList\IOException $ex) {
+						fwrite(STDERR, "Builder.php: Cannot read PLIST file" . $tpl_conf['colorTemplate']);
+						exit(66);
+					}
+					catch (Exception $ex) {
+						fwrite(STDERR, "Builder.php: Cannot parse PLIST file" . $tpl_conf['colorTemplate']);
+						exit(66);
+					}
+					if (!$term_plist) {
+						fwrite(STDERR, "Builder.php: PLIST file" . $tpl_conf['colorTemplate'] . " is empty");
+						exit(66);
+					}
+				}
+
+				$file_path = "templates/$tpl_name/" . $tpl_conf['output'];
 
 				// Remove all previous output
 				array_map('unlink', glob(
-					$file_path. '/base16-*' . $tpl_conf['extension']
+					"$file_path/" . (@$tpl_conf['noPrefix'] ? '' : 'base16-') . '*' . $tpl_conf['extension']
 				));
 
 				// Loop scheme repositories
@@ -82,16 +153,65 @@ switch (@$argv[1]) {
 						$sch_data = $builder->parse($sch_file);
 						$tpl_data = $builder->buildTemplateData($sch_data);
 
-						$file_name = 'base16-'.$tpl_data['scheme-slug']
+						$file_name = (@$tpl_conf['noPrefix'] ? '' : 'base16-')
+							. (@$tpl_conf['niceFilename'] ? ucwords(strtr($tpl_data['scheme-slug'], '-', ' ')) : $tpl_data['scheme-slug'])
 							. $tpl_conf['extension'];
-						
+
 						$render = $builder->renderTemplate(
 							"templates/$tpl_name/templates/$tpl_file.mustache",
 							 $tpl_data);
 
+						if ($term_plist && $color) {
+							try {
+								$data = Yaml::parse($render);
+							}
+							catch (ParseException $ex) {
+								fwrite(STDERR, "Cannot parse YAML data generated from $tpl_file.mustache");
+								exit(1);
+							}
+							try {
+								foreach ($data as $key => $val) {
+									if (($prop = $term_plist->get(0)->get($key))) {
+										if (substr($key, -5) == 'Color') {
+											$color->get(0)->get('$objects')->get(1)->get('NSRGB')->setValue($val);
+											// This is what should work:
+											// $prop->setValue($color->toBinary());
+											// Here is what we have to do instead, else the color is an invalid plist
+											$color->saveXML("color.plist");
+											exec('plutil -convert binary1 color.plist');
+											$prop->setValue(file_get_contents("color.plist"));
+										}
+										else {
+											$prop->setValue($val);
+										}
+									}
+									else {
+										if (substr($key, -5) == 'Color') {
+											$color->get(0)->get('$objects')->get(1)->get('NSRGB')->setValue($val);
+											// This is what should work:
+											// $term_plist->get(0)->add($key, new CFData($color->toBinary()));
+											// Here is what we have to do instead, else the color is an invalid plist
+											$color->saveXML("color.plist");
+											exec('plutil -convert binary1 color.plist');
+											$term_plist->get(0)->add($key, new CFData(file_get_contents("color.plist")));
+										}
+										else {
+											$term_plist->get(0)->add($key, $detector->toCFType($val));
+										}
+									}
+								}
+								// Clean up plist file that shouldn't be necessary in the first place
+								@unlink("color.plist");
+								$render = $term_plist->toXML();
+							}
+							catch (Exception $ex) {
+								fwrite(STDERR, "Builder.php: PLIST file is not a valid Terminal profile");
+								exit(1);
+							}
+						}
 						$builder->writeFile($file_path, $file_name, $render);
 
-						echo "Built $file_name\n";
+						echo "Built " . $tpl_conf['output'] . "/$file_name\n";
 					}
 				}
 			}

--- a/README.md
+++ b/README.md
@@ -18,5 +18,8 @@ Updates all scheme and template repositories as defined in `schemes.yaml` and `t
     php Builder.php
 Build all templates using all schemes
 
+    php Builder.php -p path/to/profile.terminal
+Same as above, but uses a Terminal.app profile as template.
+
 ## Why PHP?
 It's easy to read PHP and this Base16 Builder is not meant to be the defacto CLI builder app but serves as a simple working reference application from which others can build Base16 Builders in languages better suited to their needs.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
         "symfony/yaml": "^2.7",
         "mustache/mustache": "^2.9",
         "cocur/slugify": "^1.3",
-        "mexitek/phpcolors": "^0.4.0"
+        "mexitek/phpcolors": "^0.4.0",
+        "rodneyrehm/plist": "^2.0"
     },
      "autoload": {
         "psr-4": {"Base16\\": "src/"}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2f9fa45a67068076e6e9b1019677f913",
+    "hash": "86179d91eab2a50c6f2993c1d96a9298",
+    "content-hash": "bcc05f73c8844359584f07a60059641c",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -159,6 +160,50 @@
                 "templating"
             ],
             "time": "2015-08-15 19:23:13"
+        },
+        {
+            "name": "rodneyrehm/plist",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rodneyrehm/CFPropertyList.git",
+                "reference": "2ea0483806c989eb0518a767fa29a111bb29cb67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rodneyrehm/CFPropertyList/zipball/2ea0483806c989eb0518a767fa29a111bb29cb67",
+                "reference": "2ea0483806c989eb0518a767fa29a111bb29cb67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "CFPropertyList": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Kruse",
+                    "email": "cjk@wwwtech.de"
+                },
+                {
+                    "name": "Rodney Rehm",
+                    "email": "mail+github@rodneyrehm.de"
+                }
+            ],
+            "description": "Library for reading and writing Apple's CFPropertyList (plist) files in XML as well as binary format.",
+            "homepage": "https://github.com/rodneyrehm/CFPropertyList",
+            "keywords": [
+                "plist"
+            ],
+            "time": "2015-01-28 23:18:19"
         },
         {
             "name": "symfony/yaml",


### PR DESCRIPTION
Since the PLIST profiles of Terminal.app are more complex than the profiles of iTerm2, I had to extend the Builder to correctly handle NSColor data.
Unfortunately, plutil needs to be in the PATH for this to work. If it can’t be found, the Terminal templates will be skipped.